### PR TITLE
added naming sankey plot stages flexibility

### DIFF
--- a/man/plot_sankey.Rd
+++ b/man/plot_sankey.Rd
@@ -7,6 +7,7 @@
 plot_sankey(
   data,
   cols = c("source_country_iso3c", "exporter_iso3c", "importer_iso3c"),
+  cols_labels = c("Source", "Exporter", "Importer"),
   prop_flow_cutoff = 0.05,
   value = "live_weight_t",
   show.other = TRUE,
@@ -16,7 +17,9 @@ plot_sankey(
 \arguments{
 \item{data}{dataframe. An ARTIS trade or consumption dataframe.}
 
-\item{cols}{vector. Column names to generate the sections of the Sankey plot, in the order they should appear (left to right).}
+\item{cols}{character vector. Column names to generate the sections of the Sankey plot, in the order they should appear (left to right).}
+
+\item{cols_labels}{character vector. User-specified labels for the columns selected with cols argument.}
 
 \item{prop_flow_cutoff}{integer. A percent in which trade volumes that comprise less than x\% of the total trade are renamed as "Other". Default prop_flow_cutoff = 0.05 means trade volumes less than 5\% are labeled as "Other".}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add ability to customize text labels of sankey diagram stages. 

## Motivation and Context (link issue)
Previously not able to change or display diagram stages labels by adding layers to `exploreARTIS::plot_sankey()`. Likely because `plot_sankey()` is a custom function that wraps `ggsankey` package's `geom_sankey()` layer. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Only casually tested locally. Needs to be properly tested before merging with main branch and releasing this feature.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
